### PR TITLE
Use distribution package name for version parsing (chainlit integration error)

### DIFF
--- a/libs/langchain/langchain/__init__.py
+++ b/libs/langchain/langchain/__init__.py
@@ -18,7 +18,7 @@ _check_gigachain_community_version()
 
 
 try:
-    __version__ = metadata.version(__package__)
+    __version__ = metadata.version("gigachain")
 except metadata.PackageNotFoundError:
     # Case where package metadata is not available.
     __version__ = ""

--- a/libs/langchain/tests/unit_tests/test_package_version.py
+++ b/libs/langchain/tests/unit_tests/test_package_version.py
@@ -1,0 +1,8 @@
+import importlib
+
+from packaging.version import Version, parse
+
+
+def test_package_version_is_parsable() -> None:
+    module = importlib.import_module("langchain")
+    assert isinstance(parse(module.__version__), Version)


### PR DESCRIPTION
There is an error while running Chainlit with gigachain:
![chainlit-error](https://github.com/ai-forever/gigachain/assets/9625027/5fb1b4c5-830d-42f8-ae7c-5988792debfa)

The issue is that chainlit and langchain use import package name ("langchain") for package import, but langchain also uses this name as a distribution package name for version validation and if the validation is failed, the empty string will be assigned to the version value.
Because in our case distribution package name ("gigachain") is different form import package name ("langchain"), the error is raised while parsing the version.

https://github.com/Chainlit/chainlit/blob/aa1f7228813112931ca53266ab91c1136dfc4228/backend/chainlit/langchain/__init__.py#L1-L6
https://github.com/Chainlit/chainlit/blob/aa1f7228813112931ca53266ab91c1136dfc4228/backend/chainlit/utils.py#L72-L88
https://github.com/ai-forever/gigachain/blob/25674222a0db9d6b177c765aaca876100ef6f345/libs/langchain/langchain/__init__.py#L20-L25


**Solution**  
Use distribution package name ("gigachain") for package import in langchain.
It seems that there is no general effective solution to determine the name of the distribution package from the code, therefore hardcoded name is used.

Related link: https://stackoverflow.com/questions/60351184/how-do-i-get-the-current-package-name-setup-py

```
try:
    __version__ = metadata.version("gigachain")
except metadata.PackageNotFoundError:
    # Case where package metadata is not available.
    __version__ = ""
```

![chainlit-success](https://github.com/ai-forever/gigachain/assets/9625027/ab4960bf-8e23-4ab6-aa21-8e91aa191b68)
