### PR TITLE
Fix GigaChat payload building

### DIFF
--- a/libs/community/langchain_community/chat_models/gigachat.py
+++ b/libs/community/langchain_community/chat_models/gigachat.py
@@ -244,31 +244,30 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
     def _build_payload(self, messages: List[BaseMessage], **kwargs: Any) -> gm.Chat:
         from gigachat.models import Chat
 
-        payload = Chat(
-            messages=[_convert_message_to_dict(m) for m in messages],
-        )
+        messages_dicts = [_convert_message_to_dict(m) for m in messages]
+        kwargs.pop("messages", None)
 
-        payload.functions = kwargs.get("functions", [])
-        payload.function_call = kwargs.get("function_call", None)
+        functions = kwargs.pop("functions", [])
+        for tool in kwargs.pop("tools", []):
+            if tool.get("type", None) == "function" and isinstance(functions, List):
+                functions.append(tool["function"])
 
-        for tool in kwargs.get("tools", []):
-            if tool.get("type", None) == "function" and isinstance(
-                payload.functions, List
-            ):
-                payload.functions.append(tool["function"])
+        function_call = kwargs.pop("function_call", None)
 
-        if self.profanity_check is not None:
-            payload.profanity_check = self.profanity_check
-        if self.temperature is not None:
-            payload.temperature = self.temperature
-        if self.top_p is not None:
-            payload.top_p = self.top_p
-        if self.max_tokens is not None:
-            payload.max_tokens = self.max_tokens
-        if self.repetition_penalty is not None:
-            payload.repetition_penalty = self.repetition_penalty
-        if self.update_interval is not None:
-            payload.update_interval = self.update_interval
+        payload_dict = {
+            "messages": messages_dicts,
+            "functions": functions,
+            "function_call": function_call,
+            "profanity_check": self.profanity_check,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "max_tokens": self.max_tokens,
+            "repetition_penalty": self.repetition_penalty,
+            "update_interval": self.update_interval,
+            **kwargs,
+        }
+
+        payload = Chat.parse_obj(payload_dict)
 
         if self.verbose:
             logger.warning(

--- a/libs/community/tests/unit_tests/chat_models/test_gigachat.py
+++ b/libs/community/tests/unit_tests/chat_models/test_gigachat.py
@@ -264,3 +264,15 @@ async def test_gigachat_astream(patch_gigachat_astream: None) -> None:
     actual = [chunk async for chunk in llm.astream("bar")]
 
     assert actual == expected
+
+
+def test_gigachat_build_payload_existing_parameter() -> None:
+    llm = GigaChat()
+    payload = llm._build_payload([], max_tokens=1)
+    assert payload.max_tokens == 1
+
+
+def test_gigachat_build_payload_non_existing_parameter() -> None:
+    llm = GigaChat()
+    payload = llm._build_payload([], fake_parameter=1)
+    assert getattr(payload, "fake_param", None) is None


### PR DESCRIPTION
При использовании LCEL-метода `bind()` у Runnable-объектов для `GigaChat` не учитывались новые значения параметров, передаваемые через `bind()`. 
Формирование финального списка параметров для вызова `GigaChat` происходит через метод `GigaChat._build_payload()`, логику которого изменил для передачи таких параметров.
