### PR TITLE
fix(mcp): comprehensive improvements for MCP client setup and compatibility

### DIFF
--- a/cookbook/mcp/.env.example
+++ b/cookbook/mcp/.env.example
@@ -1,2 +1,1 @@
 GIGACHAT_CREDENTIALS=
-GIGACHAT_BASE_URL="https://gigachat.sberdevices.ru/v1"

--- a/cookbook/mcp/README.md
+++ b/cookbook/mcp/README.md
@@ -30,7 +30,13 @@ MCP разработан компанией Anthropic.
 Установите зависимости:
 
 ```sh
-pip install langchain-gigachat langchain_mcp_adapters langgraph rich
+pip install -r requirements.txt
+```
+
+Или установите зависимости вручную:
+
+```sh
+pip install langchain-gigachat==0.3.11 langchain-mcp-adapters==0.1.8 langgraph==0.5.1 rich==14.0.0
 ```
 
 В папке примера создайте файл с переменными окружения `.env` и добавьте в него переменную `GIGACHAT_CREDENTIALS`:
@@ -38,6 +44,9 @@ pip install langchain-gigachat langchain_mcp_adapters langgraph rich
 ```sh
 GIGACHAT_CREDENTIALS=<ключ_авторизации>
 ```
+
+> [!NOTE]
+> Если у вас возникают проблемы с авторизацией, убедитесь, что не используете переменную `GIGACHAT_BASE_URL`. В текущей версии рекомендуется использовать только `GIGACHAT_CREDENTIALS`.
 
 О том как получить ключ авторизации — в [официальной документации GigaChat](https://developers.sber.ru/docs/ru/gigachat/quickstart/ind-using-api).
 

--- a/cookbook/mcp/agent_http.py
+++ b/cookbook/mcp/agent_http.py
@@ -25,23 +25,27 @@ def _log(ans):
 
 
 async def main():
-    async with MultiServerMCPClient(
+    # Create client without using as context manager
+    client = MultiServerMCPClient(
         {
             "math": {
                 "url": "http://localhost:8000/sse",
                 "transport": "sse",
             }
         }
-    ) as client:
-        agent = create_react_agent(model, client.get_tools())
-        
-        agent_response = await agent.ainvoke({"messages": [
-            {"role": "user", "content": "Сколько будет (3 + 5) x 12?"}]})
-        _log(agent_response)
-        
-        agent_response = await agent.ainvoke({"messages": [
-            {"role": "user", "content": "Найди сколько лет Джону Доу?"}]})
-        _log(agent_response)
+    )
+    
+    # Get tools asynchronously  
+    tools = await client.get_tools()
+    agent = create_react_agent(model, tools)
+    
+    agent_response = await agent.ainvoke({"messages": [
+        {"role": "user", "content": "Сколько будет (3 + 5) x 12?"}]})
+    _log(agent_response)
+    
+    agent_response = await agent.ainvoke({"messages": [
+        {"role": "user", "content": "Найди сколько лет Джону Доу?"}]})
+    _log(agent_response)
 
 # Run the main function
 asyncio.run(main())

--- a/cookbook/mcp/requirements.txt
+++ b/cookbook/mcp/requirements.txt
@@ -1,0 +1,4 @@
+langchain-gigachat==0.3.11
+langchain-mcp-adapters==0.1.8
+langgraph==0.5.1
+rich==14.0.0


### PR DESCRIPTION
## Problem

The MCP example in `cookbook/mcp/agent_http.py` had several issues preventing it from running properly:

1. **Async Context Manager Error**: `MultiServerMCPClient` was using `async with` syntax which is no longer supported in `langchain-mcp-adapters` 0.1.0+
2. **Authentication Issues**: `GIGACHAT_BASE_URL` in `.env.example` was causing 401 Unauthorized errors
3. **Missing Dependencies**: No `requirements.txt` with pinned versions for reproducible setup
4. **Outdated Documentation**: README referenced packages without versions

This was causing a `NotImplementedError`:

As of langchain-mcp-adapters 0.1.0, MultiServerMCPClient cannot be used as a context manager (e.g., async with MultiServerMCPClient(...)).



## Solution

This PR provides comprehensive fixes:

### 🔧 **MCP Client Compatibility**
- Removed `async with` usage for `MultiServerMCPClient`
- Updated to use recommended pattern: direct instantiation + `await client.get_tools()`

### 🔐 **Authentication Fix**
- Removed `GIGACHAT_BASE_URL` from `.env.example` that was causing auth errors
- Added guidance in README about this change

### 📦 **Dependency Management**
- Added `requirements.txt` with pinned package versions:
  - `langchain-gigachat==0.3.11`
  - `langchain-mcp-adapters==0.1.8`
  - `langgraph==0.5.1`
  - `rich==14.0.0`

### 📖 **Documentation Updates**
- Updated README to reference `requirements.txt` for installation
- Added note about `GIGACHAT_BASE_URL` removal
- Provided both `pip install -r requirements.txt` and manual installation options

## Testing

- [x] Code runs without the previous `NotImplementedError`
- [x] No more authentication errors with GigaChat
- [x] MCP tools are properly loaded and accessible to the agent
- [x] Installation instructions work with provided `requirements.txt`

## Files Changed

- `cookbook/mcp/agent_http.py`: Fixed MCP client instantiation pattern
- `cookbook/mcp/.env.example`: Removed problematic `GIGACHAT_BASE_URL`
- `cookbook/mcp/requirements.txt`: Added pinned dependencies (new file)
- `cookbook/mcp/README.md`: Updated installation and setup instructions

## Impact

This fixes the MCP example to work properly with current versions of all dependencies and provides a better setup experience for users.