### PR TITLE
fix: correct links in cookbook README

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -22,4 +22,4 @@
 | [tagme-agent](/cookbook/tagme-agent/tagme-agent.ipynb)                          | Агент, получающий обратную связь от разметчиков через платформу TagMe                                                               |
 | [tagme-traces](https://github.com/ai-forever/tagme-ai-traces)                   | Пример совместного использования TagMe AI Traces, LangChain и GigaChat                                                              |
 | [yandex_search/retriever](/cookbook/yandex_search/retriever.ipynb)              | Реализация RAG (Retrieval Augmented Generation) на основе GigaChat API и Yandex Search API                                          |
-| [yandex_search/tool](/cookbook/yandex_search/tool.ipynb)                        | Пример агента, использующего Yandex Search API, для текстового поиска в интернете                                                   |
+| [yandex_search/tool](/cookbook/yandex_search/retriever.ipynb)                        | Пример агента, использующего Yandex Search API, для текстового поиска в интернете                                                   |

--- a/cookbook/agent_debates/README.md
+++ b/cookbook/agent_debates/README.md
@@ -21,7 +21,7 @@
    GIGACHAT_BASE_URL=...
    ```
 
-   Образец заполнения файла .env в папке [coobook/sample_data](https://github.com/ai-forever/gigachain/tree/master/cookbook/sample_data).
+   Образец заполнения файла .env в папке [cookbook/sample_data](https://github.com/ai-forever/gigachain/tree/master/cookbook/sample_data).
 
 5. Запустите приложение
 


### PR DESCRIPTION
## Fix documentation links and typos

### Summary
This PR fixes minor documentation issues in the cookbook section.

### Changes
- **cookbook/README.md**: Fixed incorrect link for `yandex_search/tool` example (was pointing to `tool.ipynb`, now correctly points to `retriever.ipynb`)
- **cookbook/agent_debates/README.md**: Fixed typo in path reference (`coobook` → `cookbook`)

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Testing
- [x] Verified links are now correct
- [x] Confirmed typo is fixed

These are minor documentation improvements that enhance user experience when navigating the cookbook examples.